### PR TITLE
Remove dependency on jQuery.browser - removed in 1.8.0

### DIFF
--- a/jquery.scrollTo.js
+++ b/jquery.scrollTo.js
@@ -84,7 +84,7 @@
 
 			var doc = (elem.contentWindow || elem).document || elem.ownerDocument || elem;
 			
-			return /WebKit/.test(navigator.userAgent) || doc.compatMode == 'BackCompat' ?
+			return /webkit/.test(navigator.userAgent.toLowerCase()) || doc.compatMode == 'BackCompat' ?
 				doc.body : 
 				doc.documentElement;
 		});


### PR DESCRIPTION
jQuery.scrollTo no longer works in WebKit browsers as of jQuery 1.8.0, as _scrollable determines whether the browser is scrollable by calling $.browser.safari.

I have replaced that call with a simple test for "webkit" in the userAgent string, like jQuery.browser does. Should also cover issue #3.
