### PR TITLE
Minor to change to prevent animations from queueing up

### DIFF
--- a/jquery.scrollTo.js
+++ b/jquery.scrollTo.js
@@ -185,7 +185,8 @@
 			animate( settings.onAfter );			
 
 			function animate( callback ){
-				$elem.animate( attr, duration, settings.easing, callback && function(){
+				// Added stop() here to prevent the animations from building a queue
+				$elem.stop().animate( attr, duration, settings.easing, callback && function(){
 					callback.call(this, targ, settings);
 				});
 			};


### PR DESCRIPTION
Edited the animation function so that animations wont build up a queue. In my case, I'm using the plugin to navigate and i noticed it building up a queue when quickly going through my navigation.
