### PR TITLE
fix name for packagist.org [composer]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "flesler/jquery.scrollTo",
+    "name": "flesler/jquery.scrollto",
     "description": "Easy element scrolling using jQuery.",
     "keywords": [
         "browser", "animated", "animation",


### PR DESCRIPTION
> The package name flesler/jquery.scrollTo is invalid, it should not contain uppercase characters. We suggest using flesler/jquery.scrollto instead.
