### PR TITLE
Narrow the bower exports

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,13 @@
     "./jquery.scrollTo.js",
     "./jquery.scrollTo.min.js"
   ],
+  "ignore": [
+    "**/.*",
+    "demo",
+    "tests",
+    "changes.txt",
+    "composer.json"
+  ],
   "dependencies": {
     "jquery": ">=1.8"
   },


### PR DESCRIPTION
Narrow the exports, because we don't need tests and demo in production
