### PR TITLE
Name the AMD module

### DIFF
--- a/jquery.scrollTo.js
+++ b/jquery.scrollTo.js
@@ -11,7 +11,7 @@
 ;(function(plugin) {
     // AMD Support
     if (typeof define === 'function' && define.amd) {
-        define(['jquery'], plugin);
+        define('jquery.scrollTo', ['jquery'], plugin);
     } else {
         plugin(jQuery);
     }


### PR DESCRIPTION
My project uses a mix of "plain" scripts and requirejs scripts on its pages; plain scripts (jquery, various plugins, etc) are included on every page as part of a "common.js" bundle, and requirejs modules are loaded in some places as the need arises for them.

When scrollTo is included in a script tag, instead of being require()'d, on a page that includes requirejs, requirejs throws an error about a [`Mismatched anonymous define() module`](http://requirejs.org/docs/errors.html#mismatch).  Adding a name to the module fixes this error for me.
