### PR TITLE
Update jquery.scrollTo.js

### DIFF
--- a/jquery.scrollTo.js
+++ b/jquery.scrollTo.js
@@ -171,7 +171,7 @@
 		};
 
 		function both( val ) {
-			return $.isFunction(val) || typeof val == 'object' ? val : { top:val, left:val };
+			return ($.isFunction(val) || typeof val == 'object') && val !== null ? val : { top:val, left:val };
 		}
 
 		// AMD requirement


### PR DESCRIPTION
We really need this because when the `val` is `null` then condition returns `true` (because of `typeof null == 'object'`), and the `both` function returns `null` value which is set to `offset` variable. Later we have the following line #118 `attr[key] += offset[pos] || 0;` and as the `offset` is `null` we get error message (totally sad face goes here).
