### PR TITLE
Fix bower warning; name should be lowercase.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "jquery.scrollTo",
+  "name": "jquery.scrollto",
   "description": "Lightweight, cross-browser and highly customizable animated scrolling with jQuery",
   "homepage": "https://github.com/flesler/jquery.scrollTo",
   "main": [


### PR DESCRIPTION
The warning:

bower jquery.scrollTo#2.1.2

invalid-meta The "name" is recommended to be lowercase, can contain digits, dots, dashes
