### PR TITLE
Updated the cdnjs link in the main README to use the latest plugin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ CDN provided by [jsdelivr](http://www.jsdelivr.com/#!jquery.scrollto)
 ```
 CDN provided by [cdnjs](https://cdnjs.com/libraries/jquery-scrollTo)
 ```html
-<script src="//cdnjs.cloudflare.com/ajax/libs/jquery-scrollTo/2.1.0/jquery.scrollTo.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/jquery-scrollTo/2.1.2/jquery.scrollTo.min.js"></script>
 ```
 
 ### Downloading Manually


### PR DESCRIPTION
Not sure if the different version numbers were intentional, but I'm assuming that they weren't.  Hopefully this is what you intended! 😃 