### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ php composer.phar require --prefer-dist flesler/jquery.scrollto "*"
 
 CDN provided by [jsdelivr](http://www.jsdelivr.com/#!jquery.scrollto)
 ```html
-<script src="//cdn.jsdelivr.net/jquery.scrollto/2.1.2/jquery.scrollTo.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/jquery.scrollto@2.1.2/jquery.scrollTo.min.js"></script>
 ```
 CDN provided by [cdnjs](https://cdnjs.com/libraries/jquery-scrollTo)
 ```html


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.
I updated the link now so you don't forget to do it when you release a new version.

Feel free to ping me if you have any questions regarding this change.