### PR TITLE
handle scrolling on a body tag

### DIFF
--- a/jquery.scrollTo.js
+++ b/jquery.scrollTo.js
@@ -33,8 +33,14 @@
 	};
 
 	function isWin(elem) {
+		var nodeName = elem.nodeName.toLowerCase();
+		if (nodeName === 'body') {
+			// the body itself could be scrollable, or it could be the window
+			// so return true if the
+			return elem.clientHeight >= elem.scrollHeight && elem.clientWidth >= elem.scrollWidth;
+		}
 		return !elem.nodeName ||
-			$.inArray(elem.nodeName.toLowerCase(), ['iframe','#document','html','body']) !== -1;
+			$.inArray(nodeName, ['iframe','#document','html']) !== -1;
 	}
 
 	$.fn.scrollTo = function(target, duration, settings) {


### PR DESCRIPTION
If you have html like this:

```
<html style="overflow-y: overlay">
<head></head>
<body style="margin: 0, overflow-y: overlay">
<div style="height: 100vh;"><div style="height:2000px"></div><div id="bottom-content">Bottom Content</div></div>
</body>
</html>
```

then when running scrollTo on the body, it will not scroll to the element because it thinks the window needs to be scrolled.

This fixes that behaviour.