### PR TITLE
Use `peerDependencies` for jQuery

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "jquery.scrollTo.js",
   "license": "MIT",
   "ignore": ["**/.*","demo","tests","CHANGELOG","README.md","composer.json","bower.json"],
-  "dependencies": { "jquery": ">=1.8" },
+  "peerDependencies": { "jquery": ">=1.8" },
   "homepage": "https://github.com/flesler/jquery.scrollTo/",
   "docs": "https://github.com/flesler/jquery.scrollTo/",
   "demo": "http://demos.flesler.com/jquery/scrollTo/",


### PR DESCRIPTION
Would it make sense to specify `jquery` as a `peerDependency` to make sure it matches the version of jQuery the main project installs?